### PR TITLE
Add `safe_download` method to classes.song

### DIFF
--- a/src/grooveshark/classes/song.py
+++ b/src/grooveshark/classes/song.py
@@ -16,6 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import threading
 
 from grooveshark.const import *
 
@@ -23,7 +24,7 @@ class Song(object):
     """
     Represents a song.
     Do not use this class directly.
-        
+
     :param id: internal song id
     :param name: name
     :param artist_id: artist's id to generate an :class:`Artist` object
@@ -52,34 +53,34 @@ class Song(object):
         self._popularity = popularity
         self._artist = None
         self._album = None
-        
+
     def __str__(self):
         return '%s - %s - %s' % (self.name, self.artist.name, self.album.name)
-    
+
     @classmethod
     def from_response(cls, song, connection):
         return cls(song['SongID'], song['Name'] if 'Name' in song else song['SongName'], song['ArtistID'], song['ArtistName'], song['AlbumID'], song['AlbumName'],
                    ALBUM_COVER_URL + song['CoverArtFilename'] if song['CoverArtFilename'] else None, song['TrackNum'], song['EstimateDuration'], song['Popularity'], connection)
-    
+
     @classmethod
     def from_export(cls, export, connection):
         return cls(export['id'], export['name'], export['artist_id'], export['artist'], export['album_id'], export['album'], export['cover'],
                    export['track'], export['duration'], export['popularity'], connection)
-    
+
     @property
     def id(self):
         """
         internal song id
         """
         return self._id
-    
+
     @property
     def name(self):
         """
         song name
         """
         return self._name
-    
+
     @property
     def artist(self):
         """
@@ -88,7 +89,7 @@ class Song(object):
         if not self._artist:
             self._artist = Artist(self._artist_id, self._artist_name, self._connection)
         return self._artist
-    
+
     @property
     def album(self):
         """
@@ -97,38 +98,48 @@ class Song(object):
         if not self._album:
             self._album = Album(self._album_id, self._album_name, self._artist_id, self._artist_name, self._cover_url, self._connection)
         return self._album
-    
+
     @property
     def track(self):
         """
         track number
         """
         return self._track
-    
+
     @property
     def duration(self):
         """
         estimate song duration
         """
         return self._duration
-    
+
     @property
     def popularity(self):
         """
         popularity
         """
         return self._popularity
-    
+
     @property
     def stream(self):
         """
         :class:`Stream` object for playing
         """
+        # Add song to queue
+        self._connection.request('addSongsToQueue',
+                                 {'songIDsArtistIDs': [{'artistID': self.artist.id,
+                                                        'source': 'user',
+                                                        'songID': self.id,
+                                                        'songQueueSongID': 1}],
+                                  'songQueueID': self._connection.session.queue},
+                                 self._connection.header('addSongsToQueue', 'jsqueue'))
+
+
         stream_info = self._connection.request('getStreamKeyFromSongIDEx', {'songID' : self.id, 'country' : self._connection.session.country,
                                                                             'prefetch' : False, 'mobile' : False},
                                                self._connection.header('getStreamKeyFromSongIDEx', 'jsqueue'))[1]
         return Stream(stream_info['ip'], stream_info['streamKey'], self._connection)
-    
+
     def export(self):
         """
         Returns a dictionary with all song information.
@@ -162,10 +173,53 @@ class Song(object):
         """
         formatted = self.format(song_name)
         path = os.path.expanduser(directory) + os.path.sep + formatted + '.mp3'
-
-        with open(path, 'wb') as f:
-            f.write(self.stream.data.read())
+        try:
+            raw = self.safe_download()
+            with open(path, 'wb') as f:
+                f.write(raw)
+        except:
+            raise
         return formatted
+
+    def safe_download(self):
+        """Download a song respecting Grooveshark's API.
+
+        :return: The raw song data.
+        """
+        def _markStreamKeyOver30Seconds(stream):
+            self._connection.request('markStreamKeyOver30Seconds',
+                                     {'streamServerID': stream.ip,
+                                      'artistID': self.artist.id,
+                                      'songQueueID': self._connection.session.queue,
+                                      'songID': self.id,
+                                      'songQueueSongID': 1,
+                                      'streamKey': stream.key},
+                                     self._connection.header('markStreamKeyOver30Seconds',
+                                                             'jsqueue'))
+
+        stream = self.stream
+        timer = threading.Timer(30, _markStreamKeyOver30Seconds, [stream])
+        timer.start()
+        raw = stream.data.read()
+        if len(raw) == stream.size:
+            timer.cancel()
+            self._connection.request('markSongDownloadedEx',
+                                     {'streamServerID': stream.ip,
+                                      'songID': self.id,
+                                      'streamKey': stream.key},
+                                     self._connection.header('markSongDownloadedEx',
+                                                             'jsqueue'))
+            self._connection.request('removeSongsFromQueue',
+                                     {'userRemoved':True,
+                                      'songQueueID': self._connection.session.queue,
+                                      'songQueueSongIDs': [1]},
+                                     self._connection.header('removeSongsFromQueue',
+                                                             'jsqueue'))
+            return raw
+        else:
+            raise ValueError("Content-Length {}, but read {}"
+                             .format(stream.size, len(raw)))
+
 
 from grooveshark.classes.artist import Artist
 from grooveshark.classes.album import Album

--- a/src/grooveshark/classes/stream.py
+++ b/src/grooveshark/classes/stream.py
@@ -30,7 +30,7 @@ class Stream(object):
     """
     Get song's raw data.
     Do not use this class directly.
-        
+
     :param ip: streaming server address
     :param key: streaming key required to get the stream
     :param connection: underlying :class:`Connection` object
@@ -41,20 +41,34 @@ class Stream(object):
         self._connection = connection
         self._data = None
         self._size = None
-        
+
     def _request(self):
         request = urllib.Request('http://%s/stream.php' % (self._ip), data=urlencode({'streamKey' : self._key}).encode('utf-8'),
                                          headers={'User-Agent' : USER_AGENT})
         self._data = self._connection.urlopen(request)
         self._size = int(self.data.info()['Content-Length'])
-    
+
+    @property
+    def ip(self):
+        """
+        stream server IP
+        """
+        return self._ip
+
+    @property
+    def key(self):
+        """
+        stream key
+        """
+        return self._key
+
     @property
     def url(self):
         """
         stream URL
         """
         return 'http://%s/stream.php?streamKey=%s' % (self._ip, quote_plus(self._key))
-       
+
     @property
     def data(self):
         """
@@ -63,7 +77,7 @@ class Stream(object):
         if not self._data:
             self._request()
         return self._data
-    
+
     @property
     def size(self):
         """
@@ -71,4 +85,4 @@ class Stream(object):
         """
         if not self._size:
             self._request()
-        return self._size    
+        return self._size


### PR DESCRIPTION
Hopefully this will help avoid the 'temporary blacklisting' that
currently occurs with the `download` method, by more closely behaving as
Grooveshark's javascript client.
- The new method is (transparently) called by `download`
- Adds songs to queue before fetching stream key
- Marks streams as taking longer than 30 seconds as required by
  grooveshark
- Marks songs as downloaded
- Removes songs from queue
